### PR TITLE
Avoid possible NPEs

### DIFF
--- a/thunder-core/src/main/java/network/thunder/core/communication/processor/implementations/management/ChannelBlockchainWatcher.java
+++ b/thunder-core/src/main/java/network/thunder/core/communication/processor/implementations/management/ChannelBlockchainWatcher.java
@@ -95,7 +95,7 @@ public class ChannelBlockchainWatcher extends BlockchainWatcher {
                 return true;
             }
             if (!confirmed) {
-                if (block.getTransactions().contains(tx)) {
+                if (block != null && block.getTransactions() != null && block.getTransactions().contains(tx)) {
                     confirmed = true;
                 }
             }

--- a/thunder-core/src/main/java/network/thunder/core/helper/blockchain/bciapi/HttpClient.java
+++ b/thunder-core/src/main/java/network/thunder/core/helper/blockchain/bciapi/HttpClient.java
@@ -70,6 +70,8 @@ public class HttpClient implements HttpClientInterface {
             }
         } else if (requestMethod.equals("POST")) {
             url = new URL(BASE_URL + resource);
+        } else {
+            throw new APIException("Unsupported HTTP method: " + requestMethod);
         }
 
         HttpURLConnection conn = null;
@@ -97,10 +99,12 @@ public class HttpClient implements HttpClientInterface {
             ioException = e;
         } finally {
             try {
-                if (apiException != null) {
-                    conn.getErrorStream().close();
+                if (conn != null) {
+                    if (apiException != null) {
+                        conn.getErrorStream().close();
+                    }
+                    conn.getInputStream().close();
                 }
-                conn.getInputStream().close();
             } catch (Exception ex) {
             }
 


### PR DESCRIPTION
* In ChannelBlockchainWatcher, `block` or `block.getTransactions` could
be null
* In HttpClient#openUrl, using a HTTP method other than GET or POST
would have resulted in a null URL. Also, during exception handling, a
null connection could have been present.