### PR TITLE
Fix potential threading issue, a potential NPE and further code cleanups

### DIFF
--- a/thunder-core/src/main/java/network/thunder/core/communication/processor/implementations/management/ChannelBlockchainWatcher.java
+++ b/thunder-core/src/main/java/network/thunder/core/communication/processor/implementations/management/ChannelBlockchainWatcher.java
@@ -95,7 +95,7 @@ public class ChannelBlockchainWatcher extends BlockchainWatcher {
                 return true;
             }
             if (!confirmed) {
-                if (block.getTransactions().contains(tx)) {
+                if (block.getTransactions() != null && block.getTransactions().contains(tx)) {
                     confirmed = true;
                 }
             }

--- a/thunder-core/src/main/java/network/thunder/core/helper/blockchain/bciapi/HttpClient.java
+++ b/thunder-core/src/main/java/network/thunder/core/helper/blockchain/bciapi/HttpClient.java
@@ -143,7 +143,7 @@ public class HttpClient implements HttpClientInterface {
         BufferedReader reader = new BufferedReader(new InputStreamReader(is));
 
         StringBuilder responseStringBuilder = new StringBuilder();
-        String line = "";
+        String line;
 
         while ((line = reader.readLine()) != null) {
             responseStringBuilder.append(line);

--- a/thunder-core/src/main/java/network/thunder/core/helper/blockchain/bciapi/Output.java
+++ b/thunder-core/src/main/java/network/thunder/core/helper/blockchain/bciapi/Output.java
@@ -2,6 +2,8 @@ package network.thunder.core.helper.blockchain.bciapi;
 
 import com.google.gson.JsonObject;
 
+import java.util.Objects;
+
 /**
  * Represents a transaction output.
  */
@@ -21,7 +23,7 @@ public class Output {
         this.txIndex = txIndex;
         this.script = script;
         this.spent = spent;
-        if (address != "") {
+        if (!Objects.equals(address, "")) {
             spentToAddress = true;
         }
     }

--- a/thunder-core/src/main/java/network/thunder/core/helper/blockchain/bciapi/blockexplorer/Output.java
+++ b/thunder-core/src/main/java/network/thunder/core/helper/blockchain/bciapi/blockexplorer/Output.java
@@ -2,6 +2,8 @@ package network.thunder.core.helper.blockchain.bciapi.blockexplorer;
 
 import com.google.gson.JsonObject;
 
+import java.util.Objects;
+
 /**
  * Represents a transaction output.
  */
@@ -21,7 +23,7 @@ public class Output {
         this.txIndex = txIndex;
         this.script = script;
         this.spent = spent;
-        if (address != "") {
+        if (!Objects.equals(address, "")) {
             spentToAddress = true;
         }
     }

--- a/thunder-core/src/main/java/network/thunder/core/helper/blockchain/bciapi/wallet/Wallet.java
+++ b/thunder-core/src/main/java/network/thunder/core/helper/blockchain/bciapi/wallet/Wallet.java
@@ -98,7 +98,7 @@ public class Wallet {
      */
     public PaymentResponse sendMany (Map<String, Long> recipients, String fromAddress, Long fee, String note) throws APIException, IOException {
         Map<String, String> params = buildBasicRequest();
-        String method = null;
+        String method;
 
         if (recipients.size() == 1) {
             method = "payment";


### PR DESCRIPTION
* fix potential threading issue: `initialized` variable is non-final, its reference is reassigned, thread locks may happen on distinct references which not what synchronized is about
* String is an object not a primitive, hence equals should be used to compare it
* non-necessary empty String initialization removed 
* fixed potential NPE